### PR TITLE
Add help message prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ And then you can open a browser and go to http://localhost:3000/
 * left/right key → rotates around Y axis
 * up/down key → rotates around X axis
 * q/e → rotates arounds Z axis
+* h → shows help message
 
 ## Built With
 

--- a/public/index.html
+++ b/public/index.html
@@ -112,6 +112,9 @@
          }else if (data == 88) {
             // down arrow
             translateCamera(0, -0.5, 0)
+         }else if (data == 72) {
+             // h key
+             showHelp();
          }
          // socket.emit('confirmation', id);
       });
@@ -232,5 +235,18 @@
    <body>
       <div id = "error-container"></div>
       <script src="main.js"></script>
+      <div id="help-message"
+        style="display: none;position: absolute;top: 5%;left: 5%;color: white;font-family: sans-serif;background-color: #1e1e1e91;padding: 2%;">
+        <p>w → moves forwards (translate camera negatively on the Z axis)</p>
+        <p>s → moves backwards (translate camera positively on the Z axis)</p>
+        <p>a → moves left (translate camera negatively on the X axis)</p>
+        <p>d → moves right (translate camera positively on the X axis)</p>
+        <p>space bar → moves up (translate camera positively on the Y axis)</p>
+        <p>x → moves down (translate camera negatively on the Y axis)</p>
+        <p>left/right key → rotates around Y axis</p>
+        <p>up/down key → rotates around X axis</p>
+        <p>q/e → rotates arounds Z axis</p>
+        <p>h → show/hide this help message</p>
+    </div>
    </body>
 </html>

--- a/public/main.js
+++ b/public/main.js
@@ -554,3 +554,8 @@ function changeAngleCurrentToOriginalCamera(angle, centerPosition){
     X_AXIS_camera = new THREE.Vector3( 1, 0, 0 );
     Z_AXIS_camera = new THREE.Vector3( 0, 0, -1 );
 }
+
+function showHelp() {
+    var help = document.getElementById('help-message');
+    help.style.display = help.style.display == 'block' ? 'none' : 'block';
+}

--- a/public/main.js
+++ b/public/main.js
@@ -556,6 +556,8 @@ function changeAngleCurrentToOriginalCamera(angle, centerPosition){
 }
 
 function showHelp() {
-    var help = document.getElementById('help-message');
-    help.style.display = help.style.display == 'block' ? 'none' : 'block';
+    if (id == 1) {
+        var help = document.getElementById('help-message');
+        help.style.display = help.style.display == 'block' ? 'none' : 'block';  
+    }
 }


### PR DESCRIPTION
Adds help message prompt when 'h' key is pressed.

Uses simple show/hide `display: block` / `display: none` toggle - displays on all windows when toggled.
I'm not sure how to make it show on only one screen (if that's necessary), right now it shows on all windows. 

> Emilie